### PR TITLE
Add support for setting ain2 address

### DIFF
--- a/lib/log4js-syslog-appender.js
+++ b/lib/log4js-syslog-appender.js
@@ -38,13 +38,14 @@ function syslogAppender(config, layout) {
     var tag = config.tag || "log4js";
     var facility = config.facility || "local0";
     var hostname = config.hostname || "localhost";
+    var address = config.address || "127.0.0.1";
     var port = config.port || 514;
     var transport = config.transport || "UDP";
     var path = config.path || "/dev/log";
     var logger;
 
     if(transport === "UDP"){
-        logger = new syslog({transport: "UDP", tag: tag, facility: facility, hostname: hostname, port: port});
+        logger = new syslog({transport: "UDP", tag: tag, facility: facility, hostname: hostname, address: address, port: port});
     } else if(transport === "socket"){
         logger = new syslog({transport: "unix_dgram", tag: tag, facility: facility, path: path});
     }


### PR DESCRIPTION
This allows setting [the address](https://github.com/phuesler/ain/blob/d4f714829dac047f329028246786a9bb59b7c0ea/index.js#L255) for the syslog server in ain2.
