### PR TITLE
Update ain2 dependency for Node 10 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "lib": "lib"
     },
     "dependencies": {
-        "ain2": "^2.0.0",
+        "ain2": "^3.0.0",
         "log4js": "^0.6.36"
     },
     "devDependencies": {


### PR DESCRIPTION
This package no longer works with Node >=10 because of an outdated ain2 version (which uses an outdated unix-dgram version). If ain2 were updated to the latest, everything works again :smile: